### PR TITLE
Fixed a bug on MySQL 8.0 that prevents `DROP DATABASE` to success on databases containing q4m table

### DIFF
--- a/src/ha_queue.cc
+++ b/src/ha_queue.cc
@@ -2272,6 +2272,11 @@ void queue_connection_t::erase_owned()
   owner_mode = false;
 }
 
+static const char *ha_queue_exts[] = {
+  Q4M,
+  NullS
+};
+
 ha_queue::ha_queue(handlerton *hton, TABLE_SHARE *table_arg)
   :handler(hton, table_arg),
    share(NULL),
@@ -2297,11 +2302,6 @@ ha_queue::~ha_queue()
   bulk_delete_rows = NULL;
   free_rows_buffer(true);
 }
-
-static const char *ha_queue_exts[] = {
-  Q4M,
-  NullS
-};
 
 const char **ha_queue::bas_ext() const
 {

--- a/src/ha_queue.cc
+++ b/src/ha_queue.cc
@@ -2285,6 +2285,9 @@ ha_queue::ha_queue(handlerton *hton, TABLE_SHARE *table_arg)
    owns_delete_lock(false)
 {
   assert(ref_length == sizeof(my_off_t));
+  #if MYSQL_VERSION_ID >= 80000
+  hton->file_extensions = ha_queue_exts;
+  #endif
 }
 
 ha_queue::~ha_queue()


### PR DESCRIPTION
## Abstract

On MySQL 8.0, executing `DROP DATABASE` statements for databases containing q4m tables causes the following error:

```
mysql> DROP DATABASE some_database_containing_q4m_table;
ERROR 1010 (HY000) at line 4: Error dropping database (can't rmdir './some_database_containing_q4m_table/', errno: 17 - File exists)
```

This is because `handler::delete_table` fails to remove `*.Q4M` files.

Use of `hton->file_extensions` fixed this issue.

## Reproduction

```
$ cat query.sql
CREATE DATABASE some_database;
use some_database;
CREATE TABLE my_queue (v1 int not null, v2 varchar(255)) ENGINE=queue;
DROP DATABASE some_database;

$ mysql -h 127.0.0.1 -uroot < query.sql
ERROR 1010 (HY000) at line 4: Error dropping database (can't rmdir './some_database/', errno: 17 - File exists)
```

## Problem

On MySQL 5.7, `DROP TABLE` correctly removes `*.Q4M` files.

```
mysql> CREATE TABLE my_queue (v1 int not null, v2 varchar(255)) ENGINE=queue;

$ ls /var/lib/mysql/some_database/
db.opt  my_queue.Q4M  my_queue.frm

mysql> DROP TABLE my_queue;

$ ls /var/lib/mysql/some_database/
db.opt
```

However, on MySQL 8.0, `DROP TABLE` fails to remove `*.Q4M` files.

```
mysql> CREATE TABLE my_queue (v1 int not null, v2 varchar(255)) ENGINE=queue;

$ ls /var/lib/mysql/some_database/
my_queue.Q4M  my_queue_362.sdi

mysql> DROP TABLE my_queue;

$ ls /var/lib/mysql/some_database/
my_queue.Q4M
```

It seems that, because of this, `DROP DATABASE` fails.

## Cause

Current Q4M implementation uses `bas_ext()` to delete `*.Q4M` files:

https://github.com/q4m/q4m/blob/6cbd1bb1fbaf06c7df6d66fcc9c1eaac5669996a/src/ha_queue.cc#L2298-L2306

Until MySQL 5.7, `bas_ext()` is used in `handler::delete_table`:

https://github.com/mysql/mysql-server/blob/c4f63caa8d9f30b2850672291e0ad0928dd89d0e/sql/handler.cc#L4454-L4473

However, MySQL 8.0 no longer uses `bas_ext()`. Instead, it uses `ht->file_extensions`.

https://github.com/mysql/mysql-server/blob/a246bad76b9271cb4333634e954040a970222e0a/sql/handler.cc#L4521-L4536

Other storage engines, e.g. MyISAM, use `ht->file_extensions`

- https://github.com/mysql/mysql-server/blob/a246bad76b9271cb4333634e954040a970222e0a/storage/myisam/ha_myisam.cc#L1990
- https://github.com/mysql/mysql-server/blob/a246bad76b9271cb4333634e954040a970222e0a/storage/myisam/ha_myisam.cc#L642
